### PR TITLE
python312Packages.pandoc: init at 2.4

### DIFF
--- a/pkgs/development/python-modules/pandoc/default.nix
+++ b/pkgs/development/python-modules/pandoc/default.nix
@@ -1,0 +1,42 @@
+{
+  buildPythonPackage,
+  fetchPypi,
+  lib,
+  plumbum,
+  ply,
+  setuptools,
+}:
+
+buildPythonPackage rec {
+  pname = "pandoc";
+  version = "2.4";
+  pyproject = true;
+
+  src = fetchPypi {
+    inherit version;
+    pname = "pandoc";
+    hash = "sha256-7NH4y7f0GAxrXbShenwadN9RmZX18Ybvgc5yqcvQ3Zo=";
+  };
+
+  nativeBuildInputs = [
+    setuptools
+  ];
+
+  propagatedBuildInputs = [
+    plumbum
+    ply
+  ];
+
+  pythonImportsCheck = [ "pandoc" ];
+
+  meta = {
+    description = "Library Pandoc's data model for markdown documents";
+    homepage = "https://boisgera.github.io/pandoc/";
+    changelog = "https://github.com/boisgera/pandoc/blob/v${version}/mkdocs/changelog.md";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [
+      jupblb
+      tylerjl
+    ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8943,6 +8943,8 @@ self: super: with self; {
 
   pandas-datareader = callPackage ../development/python-modules/pandas-datareader { };
 
+  pandoc = callPackage ../development/python-modules/pandoc { };
+
   pandoc-attributes = callPackage ../development/python-modules/pandoc-attributes { };
 
   pandoc-xnos = callPackage ../development/python-modules/pandoc-xnos { };


### PR DESCRIPTION
Hey @jupblb! I saw that you have an open PR to add this into nixpkgs. I use the package heavily as well and saw some pending feeback in that PR, so I made the edits and thought I'd PR them here. If that looks good to you then maybe we can get that PR in with us listed as maintainers.

Notes:

- 2.4 came out in the interim, so I updated it to that
- Upstream prefers commits squashed so this is just two commits (your maintainer addition and the package `init`). Not sure how GitHub handles it but as far as I recall they'll want two commits so I think this is essentially correct.